### PR TITLE
Fixed compile bugs related to vm_flags and add compile docs for Fedora and Debian

### DIFF
--- a/amifldrv.c
+++ b/amifldrv.c
@@ -354,7 +354,7 @@ int AMI_chrdrv_mmap(struct file *file, struct vm_area_struct *vma)
 		return (-EINVAL);
 	}
 
-	vma->vm_flags |= VM_LOCKED;
+	vm_flags_set(vma,VM_LOCKED);
 
 	printk(KERN_INFO "%s:%d Kmalloc area %p\n",
 			__FUNCTION__, __LINE__, kmalloc_area);

--- a/compile.md
+++ b/compile.md
@@ -1,0 +1,42 @@
+# Compiling
+
+## Fedora based Linux
+
+First install the required dependencies:
+
+```
+sudo dnf groupinstall "Development Tools"
+sudo dnf install gnu-efi
+```
+
+Now install the kernel dev packages
+
+```
+sudo dnf install kernel-devel kernel-headers
+```
+
+Finish it with the following:
+
+```
+sudo make
+```
+
+## Debian based Linux
+
+First install the required dependencies:
+
+```
+sudo apt install build-essentials gnu-efi
+```
+
+Now install the kernel dev packages
+
+```
+sudo apt install kernel-dev linux-headers
+```
+
+Finish it with the following:
+
+```
+sudo make
+```


### PR DESCRIPTION
Error message:
```
In function ‘AMI_chrdrv_mmap’:
error: assignment of read-only member ‘vm_flags’

 vma->vm_flags |= VM_LOCKED;
```
Fix from https://gist.github.com/joanbm/d10e9cbbbb8e245b6e7e27b2db338faf

System: 
Fedora 38 kernel 6.3.8-200.fc38.x86_64